### PR TITLE
Rename async to avoid Rust 2018 keyword collision

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dispatch"
-version = "0.1.4"
+version = "0.2.0"
 authors = ["Steven Sheldon"]
 
 description = "Rust wrapper for Apple's Grand Central Dispatch."

--- a/examples/main.rs
+++ b/examples/main.rs
@@ -10,10 +10,10 @@ use dispatch::{Queue, QueuePriority};
 /// All printing is performed on the main queue.
 /// Repeats until the user stops entering numbers.
 fn prompt(mut sum: i32, queue: Queue) {
-    queue.clone().async(move || {
+    queue.clone().async_exec(move || {
         let main = Queue::main();
         // Print our prompt on the main thread and wait until it's complete
-        main.sync(|| {
+        main.sync_exec(|| {
             println!("Enter a number:");
         });
 
@@ -24,14 +24,14 @@ fn prompt(mut sum: i32, queue: Queue) {
         if let Ok(num) = input.trim().parse::<i32>() {
             sum += num;
             // Print the sum on the main thread and wait until it's complete
-            main.sync(|| {
+            main.sync_exec(|| {
                 println!("Sum is {}\n", sum);
             });
             // Do it again!
             prompt(sum, queue);
         } else {
             // Bail if no number was entered
-            main.async(|| {
+            main.async_exec(|| {
                 println!("Not a number, exiting.");
                 exit(0);
             });

--- a/tests-ios/prelude.rs
+++ b/tests-ios/prelude.rs
@@ -8,7 +8,7 @@ use dispatch::ffi::*;
 
 fn async_increment(queue: &Queue, num: &Arc<Mutex<i32>>) {
     let num = num.clone();
-    queue.async(move || {
+    queue.async_exec(move || {
         let mut num = num.lock().unwrap();
         *num += 1;
     });


### PR DESCRIPTION
In Rust 2018 `async` is now a keyword.  I have renamed `Queue::async` and `Queue::sync` to be `Queue::async_exec` and `Queue::sync_exec` respectively.

This naming convention is somewhat arbitrary so I'm open to changing it to something else, just not `async` ;)