### PR TITLE
Add as_raw() methods for queues, groups and semaphores.

### DIFF
--- a/src/group.rs
+++ b/src/group.rs
@@ -10,6 +10,7 @@ use crate::queue::Queue;
 /// allows for aggregate synchronization, so you can track when all the
 /// closures complete, even if they are running on different queues.
 #[derive(Debug)]
+#[repr(transparent)]
 pub struct Group {
     ptr: dispatch_group_t,
 }
@@ -79,6 +80,11 @@ impl Group {
             dispatch_group_wait(self.ptr, DISPATCH_TIME_NOW)
         };
         result == 0
+    }
+
+    /// Returns the raw underlying `dispatch_group_t` value.
+    pub fn as_raw(&self) -> dispatch_group_t {
+        self.ptr
     }
 }
 

--- a/src/queue.rs
+++ b/src/queue.rs
@@ -72,6 +72,7 @@ impl QueuePriority {
 /// For more information, see Apple's [Grand Central Dispatch reference](
 /// https://developer.apple.com/library/mac/documentation/Performance/Reference/GCD_libdispatch_Ref/index.html).
 #[derive(Debug)]
+#[repr(transparent)]
 pub struct Queue {
     pub(crate) ptr: dispatch_queue_t,
 }
@@ -280,6 +281,11 @@ impl Queue {
     /// Invocation does not resume until all `SuspendGuard`s have been dropped.
     pub fn suspend(&self) -> SuspendGuard {
         SuspendGuard::new(self)
+    }
+
+    /// Returns the raw underlying `dispatch_queue_t` value.
+    pub fn as_raw(&self) -> dispatch_queue_t {
+        self.ptr
     }
 }
 

--- a/src/sem.rs
+++ b/src/sem.rs
@@ -6,6 +6,7 @@ use crate::{time_after_delay, WaitTimeout};
 
 /// A counting semaphore.
 #[derive(Debug)]
+#[repr(transparent)]
 pub struct Semaphore {
     ptr: dispatch_semaphore_t,
 }
@@ -68,6 +69,11 @@ impl Semaphore {
     -> Result<SemaphoreGuard, WaitTimeout> {
         self.wait_timeout(timeout)?;
         Ok(SemaphoreGuard::new(self.clone()))
+    }
+
+    /// Returns the raw underlying `dispatch_semaphore_t` value.
+    pub fn as_raw(&self) -> dispatch_semaphore_t {
+        self.ptr
     }
 }
 


### PR DESCRIPTION
This pull request adds `as_raw()` methods to the `Queue`, `Group` and `Semaphore` structures to allow to use the crate in bindings when the raw pointers are needed (e.g. IONotificationPortSetDispatchQueue or some XPC APIs).