### PR TITLE
Implement unwind safety

### DIFF
--- a/examples/main.rs
+++ b/examples/main.rs
@@ -1,8 +1,8 @@
 extern crate dispatch;
 
+use dispatch::{Queue, QueuePriority};
 use std::io;
 use std::process::exit;
-use dispatch::{Queue, QueuePriority};
 
 /// Prompts for a number and adds it to the given sum.
 ///

--- a/src/ffi.rs
+++ b/src/ffi.rs
@@ -4,10 +4,12 @@
 use std::os::raw::{c_char, c_long, c_ulong, c_void};
 
 #[repr(C)]
-pub struct dispatch_object_s { _private: [u8; 0] }
+pub struct dispatch_object_s {
+    _private: [u8; 0],
+}
 
 // dispatch_block_t
-pub type dispatch_function_t = extern fn(*mut c_void);
+pub type dispatch_function_t = extern "C" fn(*mut c_void);
 pub type dispatch_semaphore_t = *mut dispatch_object_s;
 pub type dispatch_group_t = *mut dispatch_object_s;
 pub type dispatch_object_t = *mut dispatch_object_s;
@@ -25,39 +27,78 @@ pub type dispatch_time_t = u64;
 // dispatch_io_interval_flags_t
 pub type dispatch_queue_attr_t = *const dispatch_object_s;
 
-#[cfg_attr(any(target_os = "macos", target_os = "ios"),
-           link(name = "System", kind = "dylib"))]
-#[cfg_attr(not(any(target_os = "macos", target_os = "ios")),
-           link(name = "dispatch", kind = "dylib"))]
-extern {
+#[cfg_attr(
+    any(target_os = "macos", target_os = "ios"),
+    link(name = "System", kind = "dylib")
+)]
+#[cfg_attr(
+    not(any(target_os = "macos", target_os = "ios")),
+    link(name = "dispatch", kind = "dylib")
+)]
+extern "C" {
     static _dispatch_main_q: dispatch_object_s;
     static _dispatch_queue_attr_concurrent: dispatch_object_s;
 
     pub fn dispatch_get_global_queue(identifier: c_long, flags: c_ulong) -> dispatch_queue_t;
-    pub fn dispatch_queue_create(label: *const c_char, attr: dispatch_queue_attr_t) -> dispatch_queue_t;
+    pub fn dispatch_queue_create(
+        label: *const c_char,
+        attr: dispatch_queue_attr_t,
+    ) -> dispatch_queue_t;
     // dispatch_queue_attr_t dispatch_queue_attr_make_with_qos_class ( dispatch_queue_attr_t attr, dispatch_qos_class_t qos_class, int relative_priority );
     pub fn dispatch_queue_get_label(queue: dispatch_queue_t) -> *const c_char;
     pub fn dispatch_set_target_queue(object: dispatch_object_t, queue: dispatch_queue_t);
     pub fn dispatch_main();
 
     // void dispatch_async ( dispatch_queue_t queue, dispatch_block_t block );
-    pub fn dispatch_async_f(queue: dispatch_queue_t, context: *mut c_void, work: dispatch_function_t);
+    pub fn dispatch_async_f(
+        queue: dispatch_queue_t,
+        context: *mut c_void,
+        work: dispatch_function_t,
+    );
     // void dispatch_sync ( dispatch_queue_t queue, dispatch_block_t block );
-    pub fn dispatch_sync_f(queue: dispatch_queue_t, context: *mut c_void, work: dispatch_function_t);
+    pub fn dispatch_sync_f(
+        queue: dispatch_queue_t,
+        context: *mut c_void,
+        work: dispatch_function_t,
+    );
     // void dispatch_after ( dispatch_time_t when, dispatch_queue_t queue, dispatch_block_t block );
-    pub fn dispatch_after_f(when: dispatch_time_t, queue: dispatch_queue_t, context: *mut c_void, work: dispatch_function_t);
+    pub fn dispatch_after_f(
+        when: dispatch_time_t,
+        queue: dispatch_queue_t,
+        context: *mut c_void,
+        work: dispatch_function_t,
+    );
     // void dispatch_apply ( size_t iterations, dispatch_queue_t queue, void (^block)(size_t) );
-    pub fn dispatch_apply_f(iterations: usize, queue: dispatch_queue_t, context: *mut c_void, work: extern fn(*mut c_void, usize));
+    pub fn dispatch_apply_f(
+        iterations: usize,
+        queue: dispatch_queue_t,
+        context: *mut c_void,
+        work: extern "C" fn(*mut c_void, usize),
+    );
     // void dispatch_once ( dispatch_once_t *predicate, dispatch_block_t block );
-    pub fn dispatch_once_f(predicate: *mut dispatch_once_t, context: *mut c_void, function: dispatch_function_t);
+    pub fn dispatch_once_f(
+        predicate: *mut dispatch_once_t,
+        context: *mut c_void,
+        function: dispatch_function_t,
+    );
 
     // void dispatch_group_async ( dispatch_group_t group, dispatch_queue_t queue, dispatch_block_t block );
-    pub fn dispatch_group_async_f(group: dispatch_group_t, queue: dispatch_queue_t, context: *mut c_void, work: dispatch_function_t);
+    pub fn dispatch_group_async_f(
+        group: dispatch_group_t,
+        queue: dispatch_queue_t,
+        context: *mut c_void,
+        work: dispatch_function_t,
+    );
     pub fn dispatch_group_create() -> dispatch_group_t;
     pub fn dispatch_group_enter(group: dispatch_group_t);
     pub fn dispatch_group_leave(group: dispatch_group_t);
     // void dispatch_group_notify ( dispatch_group_t group, dispatch_queue_t queue, dispatch_block_t block );
-    pub fn dispatch_group_notify_f(group: dispatch_group_t, queue: dispatch_queue_t, context: *mut c_void, work: dispatch_function_t);
+    pub fn dispatch_group_notify_f(
+        group: dispatch_group_t,
+        queue: dispatch_queue_t,
+        context: *mut c_void,
+        work: dispatch_function_t,
+    );
     pub fn dispatch_group_wait(group: dispatch_group_t, timeout: dispatch_time_t) -> c_long;
 
     pub fn dispatch_get_context(object: dispatch_object_t) -> *mut c_void;
@@ -70,12 +111,21 @@ extern {
 
     pub fn dispatch_semaphore_create(value: c_long) -> dispatch_semaphore_t;
     pub fn dispatch_semaphore_signal(dsema: dispatch_semaphore_t) -> c_long;
-    pub fn dispatch_semaphore_wait(dsema: dispatch_semaphore_t, timeout: dispatch_time_t) -> c_long;
+    pub fn dispatch_semaphore_wait(dsema: dispatch_semaphore_t, timeout: dispatch_time_t)
+        -> c_long;
 
     // void dispatch_barrier_async ( dispatch_queue_t queue, dispatch_block_t block );
-    pub fn dispatch_barrier_async_f(queue: dispatch_queue_t, context: *mut c_void, work: dispatch_function_t);
+    pub fn dispatch_barrier_async_f(
+        queue: dispatch_queue_t,
+        context: *mut c_void,
+        work: dispatch_function_t,
+    );
     // void dispatch_barrier_sync ( dispatch_queue_t queue, dispatch_block_t block );
-    pub fn dispatch_barrier_sync_f(queue: dispatch_queue_t, context: *mut c_void, work: dispatch_function_t);
+    pub fn dispatch_barrier_sync_f(
+        queue: dispatch_queue_t,
+        context: *mut c_void,
+        work: dispatch_function_t,
+    );
 
     // void dispatch_source_cancel ( dispatch_source_t source );
     // dispatch_source_t dispatch_source_create ( dispatch_source_type_t type, uintptr_t handle, unsigned long mask, dispatch_queue_t queue );
@@ -136,14 +186,15 @@ pub fn dispatch_get_main_queue() -> dispatch_queue_t {
 }
 
 pub const DISPATCH_QUEUE_SERIAL: dispatch_queue_attr_t = 0 as dispatch_queue_attr_t;
-pub static DISPATCH_QUEUE_CONCURRENT: &'static dispatch_object_s = unsafe { &_dispatch_queue_attr_concurrent };
+pub static DISPATCH_QUEUE_CONCURRENT: &'static dispatch_object_s =
+    unsafe { &_dispatch_queue_attr_concurrent };
 
-pub const DISPATCH_QUEUE_PRIORITY_HIGH: c_long       = 2;
-pub const DISPATCH_QUEUE_PRIORITY_DEFAULT: c_long    = 0;
-pub const DISPATCH_QUEUE_PRIORITY_LOW: c_long        = -2;
+pub const DISPATCH_QUEUE_PRIORITY_HIGH: c_long = 2;
+pub const DISPATCH_QUEUE_PRIORITY_DEFAULT: c_long = 0;
+pub const DISPATCH_QUEUE_PRIORITY_LOW: c_long = -2;
 pub const DISPATCH_QUEUE_PRIORITY_BACKGROUND: c_long = -1 << 15;
 
-pub const DISPATCH_TIME_NOW: dispatch_time_t     = 0;
+pub const DISPATCH_TIME_NOW: dispatch_time_t = 0;
 pub const DISPATCH_TIME_FOREVER: dispatch_time_t = !0;
 
 #[cfg(test)]
@@ -155,7 +206,7 @@ mod tests {
         use std::os::raw::c_void;
         use std::ptr;
 
-        extern fn serial_queue_test_add(num: *mut c_void) {
+        extern "C" fn serial_queue_test_add(num: *mut c_void) {
             unsafe {
                 *(num as *mut u32) = 1;
             }

--- a/src/group.rs
+++ b/src/group.rs
@@ -1,8 +1,8 @@
 use std::time::Duration;
 
 use crate::ffi::*;
-use crate::{context_and_function, time_after_delay, WaitTimeout};
 use crate::queue::Queue;
+use crate::{context_and_function, time_after_delay, WaitTimeout};
 
 /// A Grand Central Dispatch group.
 ///
@@ -18,7 +18,9 @@ impl Group {
     /// Creates a new dispatch `Group`.
     pub fn create() -> Group {
         unsafe {
-            Group { ptr: dispatch_group_create() }
+            Group {
+                ptr: dispatch_group_create(),
+            }
         }
     }
 
@@ -32,7 +34,9 @@ impl Group {
     /// Submits a closure asynchronously to the given `Queue` and associates it
     /// with self.
     pub fn exec_async<F>(&self, queue: &Queue, work: F)
-            where F: 'static + Send + FnOnce() {
+    where
+        F: 'static + Send + FnOnce(),
+    {
         let (context, work) = context_and_function(work);
         unsafe {
             dispatch_group_async_f(self.ptr, queue.ptr, context, work);
@@ -43,7 +47,9 @@ impl Group {
     /// associated with self have completed.
     /// If self is empty, the closure is submitted immediately.
     pub fn notify<F>(&self, queue: &Queue, work: F)
-            where F: 'static + Send + FnOnce() {
+    where
+        F: 'static + Send + FnOnce(),
+    {
         let (context, work) = context_and_function(work);
         unsafe {
             dispatch_group_notify_f(self.ptr, queue.ptr, context, work);
@@ -52,9 +58,7 @@ impl Group {
 
     /// Waits synchronously for all tasks associated with self to complete.
     pub fn wait(&self) {
-        let result = unsafe {
-            dispatch_group_wait(self.ptr, DISPATCH_TIME_FOREVER)
-        };
+        let result = unsafe { dispatch_group_wait(self.ptr, DISPATCH_TIME_FOREVER) };
         assert!(result == 0, "Dispatch group wait errored");
     }
 
@@ -63,9 +67,7 @@ impl Group {
     /// Returns true if the tasks completed or false if the timeout elapsed.
     pub fn wait_timeout(&self, timeout: Duration) -> Result<(), WaitTimeout> {
         let when = time_after_delay(timeout);
-        let result = unsafe {
-            dispatch_group_wait(self.ptr, when)
-        };
+        let result = unsafe { dispatch_group_wait(self.ptr, when) };
         if result == 0 {
             Ok(())
         } else {
@@ -75,15 +77,13 @@ impl Group {
 
     /// Returns whether self is currently empty.
     pub fn is_empty(&self) -> bool {
-        let result = unsafe {
-            dispatch_group_wait(self.ptr, DISPATCH_TIME_NOW)
-        };
+        let result = unsafe { dispatch_group_wait(self.ptr, DISPATCH_TIME_NOW) };
         result == 0
     }
 }
 
-unsafe impl Sync for Group { }
-unsafe impl Send for Group { }
+unsafe impl Sync for Group {}
+unsafe impl Send for Group {}
 
 impl Clone for Group {
     fn clone(&self) -> Self {
@@ -113,11 +113,13 @@ impl GroupGuard {
         unsafe {
             dispatch_group_enter(group.ptr);
         }
-        GroupGuard { group: group.clone() }
+        GroupGuard {
+            group: group.clone(),
+        }
     }
 
     /// Drops self, leaving the `Group`.
-    pub fn leave(self) { }
+    pub fn leave(self) {}
 }
 
 impl Clone for GroupGuard {
@@ -136,9 +138,9 @@ impl Drop for GroupGuard {
 
 #[cfg(test)]
 mod tests {
-    use std::sync::{Arc, Mutex};
-    use crate::{Queue, QueueAttribute};
     use super::Group;
+    use crate::{Queue, QueueAttribute};
+    use std::sync::{Arc, Mutex};
 
     #[test]
     fn test_group() {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -136,7 +136,13 @@ where
 
     // If the closure panicked, resume unwinding
     match sync_context.result.transpose() {
-        Ok(res) => res,
+        Ok(res) => {
+            if res.is_none() {
+                // if the closure didn't run (for example when using `Once`), free the box
+                std::mem::drop(unsafe { Box::from_raw(sync_context.closure) });
+            }
+            res
+        }
         Err(unwind_payload) => std::panic::resume_unwind(unwind_payload),
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -44,10 +44,11 @@ assert!(nums[0] == "2");
 
 #![warn(missing_docs)]
 
+use std::convert::TryFrom;
 use std::error::Error;
 use std::fmt;
-use std::mem;
 use std::os::raw::c_void;
+use std::panic::AssertUnwindSafe;
 use std::time::Duration;
 
 use crate::ffi::*;
@@ -79,68 +80,83 @@ impl fmt::Display for WaitTimeout {
 impl Error for WaitTimeout {}
 
 fn time_after_delay(delay: Duration) -> dispatch_time_t {
-    delay
-        .as_secs()
-        .checked_mul(1_000_000_000)
-        .and_then(|i| i.checked_add(delay.subsec_nanos() as u64))
-        .and_then(|i| {
-            if i < (i64::max_value() as u64) {
-                Some(i as i64)
-            } else {
-                None
-            }
-        })
-        .map_or(DISPATCH_TIME_FOREVER, |i| unsafe {
-            dispatch_time(DISPATCH_TIME_NOW, i)
-        })
+    i64::try_from(delay.as_nanos()).map_or(DISPATCH_TIME_FOREVER, |i| unsafe {
+        dispatch_time(DISPATCH_TIME_NOW, i)
+    })
 }
 
 fn context_and_function<F>(closure: F) -> (*mut c_void, dispatch_function_t)
 where
-    F: FnOnce(),
+    F: 'static + FnOnce(),
 {
-    extern "C" fn work_execute_closure<F>(context: Box<F>)
+    extern "C" fn work_execute_closure<F>(context: *mut c_void)
     where
         F: FnOnce(),
     {
-        (*context)();
+        let closure: Box<F> = unsafe { Box::from_raw(context as *mut _) };
+        if std::panic::catch_unwind(AssertUnwindSafe(closure)).is_err() {
+            // Abort to prevent unwinding across FFI
+            std::process::abort();
+        }
     }
 
     let closure = Box::new(closure);
-    let func: extern "C" fn(Box<F>) = work_execute_closure::<F>;
-    unsafe { (mem::transmute(closure), mem::transmute(func)) }
+    let func: dispatch_function_t = work_execute_closure::<F>;
+    (Box::into_raw(closure) as *mut c_void, func)
 }
 
-fn context_and_sync_function<F>(closure: &mut Option<F>) -> (*mut c_void, dispatch_function_t)
+fn with_context_and_sync_function<F, T>(
+    closure: F,
+    wrapper: impl FnOnce(*mut c_void, dispatch_function_t),
+) -> Option<T>
 where
-    F: FnOnce(),
+    F: FnOnce() -> T,
 {
-    extern "C" fn work_read_closure<F>(context: &mut Option<F>)
-    where
-        F: FnOnce(),
-    {
-        // This is always passed Some, so it's safe to unwrap
-        let closure = context.take().unwrap();
-        closure();
+    #[derive(Debug)]
+    struct SyncContext<F, T> {
+        closure: *mut F,
+        result: Option<std::thread::Result<T>>,
     }
 
-    let context: *mut Option<F> = closure;
-    let func: extern "C" fn(&mut Option<F>) = work_read_closure::<F>;
-    unsafe { (context as *mut c_void, mem::transmute(func)) }
+    extern "C" fn work_execute_closure<F, T>(context: *mut c_void)
+    where
+        F: FnOnce() -> T,
+    {
+        let sync_context: &mut SyncContext<F, T> = unsafe { &mut *(context as *mut _) };
+        let closure = unsafe { Box::from_raw(sync_context.closure) };
+        sync_context.result = Some(std::panic::catch_unwind(AssertUnwindSafe(closure)));
+    }
+
+    let mut sync_context: SyncContext<F, T> = SyncContext {
+        closure: Box::into_raw(Box::new(closure)),
+        result: None,
+    };
+    let func: dispatch_function_t = work_execute_closure::<F, T>;
+    wrapper(&mut sync_context as *mut _ as *mut c_void, func);
+
+    // If the closure panicked, resume unwinding
+    match sync_context.result.transpose() {
+        Ok(res) => res,
+        Err(unwind_payload) => std::panic::resume_unwind(unwind_payload),
+    }
 }
 
 fn context_and_apply_function<F>(closure: &F) -> (*mut c_void, extern "C" fn(*mut c_void, usize))
 where
     F: Fn(usize),
 {
-    extern "C" fn work_apply_closure<F>(context: &F, iter: usize)
+    extern "C" fn work_apply_closure<F>(context: *mut c_void, iter: usize)
     where
         F: Fn(usize),
     {
-        context(iter);
+        let context: &F = unsafe { &*(context as *const _) };
+        if std::panic::catch_unwind(AssertUnwindSafe(|| context(iter))).is_err() {
+            // Abort to prevent unwinding across FFI
+            std::process::abort();
+        }
     }
 
     let context: *const F = closure;
-    let func: extern "C" fn(&F, usize) = work_apply_closure::<F>;
-    unsafe { (context as *mut c_void, mem::transmute(func)) }
+    let func: extern "C" fn(*mut c_void, usize) = work_apply_closure::<F>;
+    (context as *mut c_void, func)
 }

--- a/src/once.rs
+++ b/src/once.rs
@@ -1,7 +1,7 @@
 use std::cell::UnsafeCell;
 
-use crate::context_and_sync_function;
 use crate::ffi::*;
+use crate::with_context_and_sync_function;
 
 /// A predicate used to execute a closure only once for the lifetime of an
 /// application.
@@ -34,11 +34,9 @@ impl Once {
         where
             F: FnOnce(),
         {
-            let mut work = Some(work);
-            let (context, work) = context_and_sync_function(&mut work);
-            unsafe {
+            with_context_and_sync_function(work, |context, work| unsafe {
                 dispatch_once_f(predicate, context, work);
-            }
+            });
         }
 
         unsafe {

--- a/src/once.rs
+++ b/src/once.rs
@@ -1,7 +1,7 @@
 use std::cell::UnsafeCell;
 
-use crate::ffi::*;
 use crate::context_and_sync_function;
+use crate::ffi::*;
 
 /// A predicate used to execute a closure only once for the lifetime of an
 /// application.
@@ -13,7 +13,9 @@ pub struct Once {
 impl Once {
     /// Creates a new `Once`.
     pub const fn new() -> Once {
-        Once { predicate: UnsafeCell::new(0) }
+        Once {
+            predicate: UnsafeCell::new(0),
+        }
     }
 
     /// Executes a closure once, ensuring that no other closure has been or
@@ -22,11 +24,16 @@ impl Once {
     /// If called simultaneously from multiple threads, waits synchronously
     // until the work has completed.
     #[inline(always)]
-    pub fn call_once<F>(&'static self, work: F) where F: FnOnce() {
+    pub fn call_once<F>(&'static self, work: F)
+    where
+        F: FnOnce(),
+    {
         #[cold]
         #[inline(never)]
         fn once<F>(predicate: *mut dispatch_once_t, work: F)
-                where F: FnOnce() {
+        where
+            F: FnOnce(),
+        {
             let mut work = Some(work);
             let (context, work) = context_and_sync_function(&mut work);
             unsafe {
@@ -43,7 +50,7 @@ impl Once {
     }
 }
 
-unsafe impl Sync for Once { }
+unsafe impl Sync for Once {}
 
 #[cfg(test)]
 mod tests {

--- a/src/queue.rs
+++ b/src/queue.rs
@@ -6,8 +6,7 @@ use std::time::Duration;
 
 use crate::ffi::*;
 use crate::{
-    context_and_function, context_and_sync_function, context_and_apply_function,
-    time_after_delay,
+    context_and_apply_function, context_and_function, context_and_sync_function, time_after_delay,
 };
 
 /// The type of a dispatch queue.
@@ -59,9 +58,9 @@ pub enum QueuePriority {
 impl QueuePriority {
     fn as_raw(&self) -> c_long {
         match *self {
-            QueuePriority::High       => DISPATCH_QUEUE_PRIORITY_HIGH,
-            QueuePriority::Default    => DISPATCH_QUEUE_PRIORITY_DEFAULT,
-            QueuePriority::Low        => DISPATCH_QUEUE_PRIORITY_LOW,
+            QueuePriority::High => DISPATCH_QUEUE_PRIORITY_HIGH,
+            QueuePriority::Default => DISPATCH_QUEUE_PRIORITY_DEFAULT,
+            QueuePriority::Low => DISPATCH_QUEUE_PRIORITY_LOW,
             QueuePriority::Background => DISPATCH_QUEUE_PRIORITY_BACKGROUND,
         }
     }
@@ -100,9 +99,7 @@ impl Queue {
     /// Creates a new dispatch `Queue`.
     pub fn create(label: &str, attr: QueueAttribute) -> Self {
         let label = CString::new(label).unwrap();
-        let queue = unsafe {
-            dispatch_queue_create(label.as_ptr(), attr.as_raw())
-        };
+        let queue = unsafe { dispatch_queue_create(label.as_ptr(), attr.as_raw()) };
         Queue { ptr: queue }
     }
 
@@ -111,8 +108,7 @@ impl Queue {
     /// A dispatch queue's priority is inherited from its target queue.
     /// Additionally, if both the queue and its target are serial queues,
     /// their blocks will not be invoked concurrently.
-    pub fn with_target_queue(label: &str, attr: QueueAttribute, target: &Queue)
-            -> Self {
+    pub fn with_target_queue(label: &str, attr: QueueAttribute, target: &Queue) -> Self {
         let queue = Queue::create(label, attr);
         unsafe {
             dispatch_set_target_queue(queue.ptr, target.ptr);
@@ -134,7 +130,10 @@ impl Queue {
 
     /// Submits a closure for execution on self and waits until it completes.
     pub fn exec_sync<T, F>(&self, work: F) -> T
-            where F: Send + FnOnce() -> T, T: Send {
+    where
+        F: Send + FnOnce() -> T,
+        T: Send,
+    {
         let mut result = None;
         {
             let result_ref = &mut result;
@@ -154,7 +153,10 @@ impl Queue {
 
     /// Submits a closure for asynchronous execution on self and returns
     /// immediately.
-    pub fn exec_async<F>(&self, work: F) where F: 'static + Send + FnOnce() {
+    pub fn exec_async<F>(&self, work: F)
+    where
+        F: 'static + Send + FnOnce(),
+    {
         let (context, work) = context_and_function(work);
         unsafe {
             dispatch_async_f(self.ptr, context, work);
@@ -164,7 +166,9 @@ impl Queue {
     /// After the specified delay, submits a closure for asynchronous execution
     /// on self.
     pub fn exec_after<F>(&self, delay: Duration, work: F)
-            where F: 'static + Send + FnOnce() {
+    where
+        F: 'static + Send + FnOnce(),
+    {
         let when = time_after_delay(delay);
         let (context, work) = context_and_function(work);
         unsafe {
@@ -175,7 +179,9 @@ impl Queue {
     /// Submits a closure to be executed on self the given number of iterations
     /// and waits until it completes.
     pub fn apply<F>(&self, iterations: usize, work: F)
-            where F: Sync + Fn(usize) {
+    where
+        F: Sync + Fn(usize),
+    {
         let (context, work) = context_and_apply_function(&work);
         unsafe {
             dispatch_apply_f(iterations, self.ptr, context, work);
@@ -185,7 +191,10 @@ impl Queue {
     /// Submits a closure to be executed on self for each element of the
     /// provided slice and waits until it completes.
     pub fn for_each<T, F>(&self, slice: &mut [T], work: F)
-            where F: Sync + Fn(&mut T), T: Send {
+    where
+        F: Sync + Fn(&mut T),
+        T: Send,
+    {
         let slice_ptr = slice.as_mut_ptr();
         let work = move |i| unsafe {
             work(&mut *slice_ptr.offset(i as isize));
@@ -199,7 +208,11 @@ impl Queue {
     /// Submits a closure to be executed on self for each element of the
     /// provided vector and returns a `Vec` of the mapped elements.
     pub fn map<T, U, F>(&self, vec: Vec<T>, work: F) -> Vec<U>
-            where F: Sync + Fn(T) -> U, T: Send, U: Send {
+    where
+        F: Sync + Fn(T) -> U,
+        T: Send,
+        U: Send,
+    {
         let mut src = vec;
         let len = src.len();
         let src_ptr = src.as_ptr();
@@ -234,7 +247,10 @@ impl Queue {
     /// If self is a serial queue or one of the global concurrent queues,
     /// this method behaves like the normal `sync` method.
     pub fn barrier_sync<T, F>(&self, work: F) -> T
-            where F: Send + FnOnce() -> T, T: Send {
+    where
+        F: Send + FnOnce() -> T,
+        T: Send,
+    {
         let mut result = None;
         {
             let result_ref = &mut result;
@@ -265,7 +281,9 @@ impl Queue {
     /// If self is a serial queue or one of the global concurrent queues,
     /// this method behaves like the normal `async` method.
     pub fn barrier_async<F>(&self, work: F)
-            where F: 'static + Send + FnOnce() {
+    where
+        F: 'static + Send + FnOnce(),
+    {
         let (context, work) = context_and_function(work);
         unsafe {
             dispatch_barrier_async_f(self.ptr, context, work);
@@ -283,8 +301,8 @@ impl Queue {
     }
 }
 
-unsafe impl Sync for Queue { }
-unsafe impl Send for Queue { }
+unsafe impl Sync for Queue {}
+unsafe impl Send for Queue {}
 
 impl Clone for Queue {
     fn clone(&self) -> Self {
@@ -314,11 +332,13 @@ impl SuspendGuard {
         unsafe {
             dispatch_suspend(queue.ptr);
         }
-        SuspendGuard { queue: queue.clone() }
+        SuspendGuard {
+            queue: queue.clone(),
+        }
     }
 
     /// Drops self, allowing the suspended `Queue` to resume.
-    pub fn resume(self) { }
+    pub fn resume(self) {}
 }
 
 impl Clone for SuspendGuard {
@@ -337,10 +357,10 @@ impl Drop for SuspendGuard {
 
 #[cfg(test)]
 mod tests {
+    use super::*;
+    use crate::Group;
     use std::sync::{Arc, Mutex};
     use std::time::{Duration, Instant};
-    use crate::Group;
-    use super::*;
 
     fn async_increment(queue: &Queue, num: &Arc<Mutex<i32>>) {
         let num = num.clone();

--- a/src/sem.rs
+++ b/src/sem.rs
@@ -18,26 +18,20 @@ impl Semaphore {
     /// successful calls to `wait` than `signal`, the system assumes the
     /// `Semaphore` is still in use and will abort if it is disposed.
     pub fn new(value: u32) -> Self {
-        let ptr = unsafe {
-            dispatch_semaphore_create(value as c_long)
-        };
+        let ptr = unsafe { dispatch_semaphore_create(value as c_long) };
         Semaphore { ptr }
     }
 
     /// Wait for (decrement) self.
     pub fn wait(&self) {
-        let result = unsafe {
-            dispatch_semaphore_wait(self.ptr, DISPATCH_TIME_FOREVER)
-        };
+        let result = unsafe { dispatch_semaphore_wait(self.ptr, DISPATCH_TIME_FOREVER) };
         assert!(result == 0, "Dispatch semaphore wait errored");
     }
 
     /// Wait for (decrement) self until the specified timeout has elapsed.
     pub fn wait_timeout(&self, timeout: Duration) -> Result<(), WaitTimeout> {
         let when = time_after_delay(timeout);
-        let result = unsafe {
-            dispatch_semaphore_wait(self.ptr, when)
-        };
+        let result = unsafe { dispatch_semaphore_wait(self.ptr, when) };
         if result == 0 {
             Ok(())
         } else {
@@ -50,9 +44,7 @@ impl Semaphore {
     /// If the previous value was less than zero, this method wakes a waiting thread.
     /// Returns `true` if a thread is woken or `false` otherwise.
     pub fn signal(&self) -> bool {
-        unsafe {
-            dispatch_semaphore_signal(self.ptr) != 0
-        }
+        unsafe { dispatch_semaphore_signal(self.ptr) != 0 }
     }
 
     /// Wait to access a resource protected by self.
@@ -64,8 +56,7 @@ impl Semaphore {
 
     /// Wait until the specified timeout to access a resource protected by self.
     /// This decrements self and returns a guard that increments when dropped.
-    pub fn access_timeout(&self, timeout: Duration)
-    -> Result<SemaphoreGuard, WaitTimeout> {
+    pub fn access_timeout(&self, timeout: Duration) -> Result<SemaphoreGuard, WaitTimeout> {
         self.wait_timeout(timeout)?;
         Ok(SemaphoreGuard::new(self.clone()))
     }
@@ -103,7 +94,7 @@ impl SemaphoreGuard {
     }
 
     /// Drops self, signaling the `Semaphore`.
-    pub fn signal(self) { }
+    pub fn signal(self) {}
 }
 
 impl Drop for SemaphoreGuard {


### PR DESCRIPTION
Currently it is UB for Rust code to unwind into FFI (except when using `extern "C-unwind"`, but I don't know if that would be safe to use within libdispatch).

For async functions, this PR simply aborts the process if the closure panics. For synchronous functions, the panic will be automatically resumed once the dispatch call returns.

While I don't believe this should have a major impact on performance, it's possible, and should probably be benchmarked if possible.